### PR TITLE
Course mates view by student backend

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,6 +8,7 @@ namespace Domain.Contracts.Repositories
     public interface ICourseRepository
     {
         Task<IEnumerable<Course>> GetCoursesByTeacherAsync(Guid teacherId);
+        Task<Course?> GetCourseWithStudentsAsync(Guid studentId);
         Task<Course?> GetCourseWithTeachersAsync(Guid courseId);
     }
 }

--- a/Domain.Models/Entities/ApplicationUser.cs
+++ b/Domain.Models/Entities/ApplicationUser.cs
@@ -11,5 +11,4 @@ public class ApplicationUser : IdentityUser
     public Guid? CourseId { get; set; }
     public Course? Course { get; set; }
     public ICollection<Course> CoursesTaught { get; set; } = new List<Course>();
-
 }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -41,6 +41,12 @@ namespace LMS.Infractructure.Repositories
                 .Include(c => c.Teachers)
                 .FirstOrDefaultAsync(c => c.Id == courseId);
         }
+        public async Task<Course?> GetCourseWithStudentsAsync(Guid courseId)
+        {
+            return await context.Courses
+                .Include(c => c.Students) // This loads the Students collection
+                .FirstOrDefaultAsync(c => c.Id == courseId);
+        }
 
     }
 }

--- a/LMS.Infractructure/Repositories/StudentRepository.cs
+++ b/LMS.Infractructure/Repositories/StudentRepository.cs
@@ -27,5 +27,12 @@ namespace LMS.Infractructure.Repositories
             return await _context.Users
                 .FirstOrDefaultAsync(u => u.Id == studentId.ToString());
         }
+
+        //public async Task<IEnumerable<ApplicationUser?>> GetStudentsByCourseIdAsync(Guid courseId)
+        //{
+        //    return await _context.Students
+        //        .Where(s => s.CourseId == courseId)
+        //        .ToListAsync();
+        //}
     }
 }

--- a/LMS.Presentation/Controllers/StudentController.cs
+++ b/LMS.Presentation/Controllers/StudentController.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using LMS.Shared.DTOs.CourseDTOs;
+using LMS.Shared.DTOs.ModuleDTOs;
+using LMS.Shared.DTOs.UserDTOs;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
-using LMS.Shared.DTOs.CourseDTOs;
-using LMS.Shared.DTOs.ModuleDTOs;
 
 namespace LMS.Presentation.Controllers
 {
@@ -85,7 +86,7 @@ namespace LMS.Presentation.Controllers
         [HttpGet("{id}/course/students")]
         public async Task<IActionResult> GetCoursemates(Guid id)
         {
-            var studentDto = await serviceManager.StudentService.GetCoursematesAsync(id);
+            IEnumerable<StudentDto> studentDto = await serviceManager.StudentService.GetCoursematesAsync(id);
             if (studentDto == null)
                 return NotFound($"No course mates found for student with id {id}");
             return Ok(studentDto);

--- a/LMS.Presentation/Controllers/StudentController.cs
+++ b/LMS.Presentation/Controllers/StudentController.cs
@@ -82,5 +82,14 @@ namespace LMS.Presentation.Controllers
                 return StatusCode(500, new { message = "An unexpected error occurred.", details = ex.Message });
             }
         }
+        [HttpGet("{id}/course/students")]
+        public async Task<IActionResult> GetCoursemates(Guid id)
+        {
+            var studentDto = await serviceManager.StudentService.GetCoursematesAsync(id);
+            if (studentDto == null)
+                return NotFound($"No course mates found for student with id {id}");
+            return Ok(studentDto);
+
+        }
     }
 }

--- a/LMS.Services/StudentService.cs
+++ b/LMS.Services/StudentService.cs
@@ -107,29 +107,30 @@ namespace LMS.Services
             };
         }
 
+
         public async Task<IEnumerable<StudentDto>> GetCoursematesAsync(Guid studentId)
         {
-            // Get student
             var student = await unitOfWork.Students.GetStudentByIdAsync(studentId);
-
             if (student == null || student.CourseId == null)
             {
-                return null;
+                return Enumerable.Empty<StudentDto>();
             }
 
-            var course = await unitOfWork.Courses.GetCourseWithTeachersAsync(student.CourseId.Value);     //get course student is enrolled in
+            var course = await unitOfWork.Courses.GetCourseWithStudentsAsync(student.CourseId.Value);
+            if (course == null || course.Students == null)
+                return Enumerable.Empty<StudentDto>();
 
-            if (course == null)
-                return null;
+            var coursemates = course.Students
+                //.Where(s => s.Id != studentId) // Compare Guid with Guid
+                .Select(s => new StudentDto
+                {
+                    FirstName = s.FirstName ?? string.Empty,
+                    LastName = s.LastName ?? string.Empty,
+                    Email = s.Email ?? string.Empty,
+                })
+                .ToList();
 
-            IEnumerable<StudentDto> studentDto = course.Students.Select(s => new StudentDto //get all students in that course
-            {
-                Id = s.Id,
-                FirstName = s.FirstName ?? string.Empty,
-                LastName = s.LastName ?? string.Empty,
-                Email = s.Email ?? string.Empty,
-            }).ToList();
-            return studentDto;
+            return coursemates;
         }
     }
 }

--- a/LMS.Services/StudentService.cs
+++ b/LMS.Services/StudentService.cs
@@ -147,7 +147,6 @@ namespace LMS.Services
                 return Enumerable.Empty<StudentDto>();
 
             var coursemates = course.Students
-                //.Where(s => s.Id != studentId) // Compare Guid with Guid
                 .Select(s => new StudentDto
                 {
                     FirstName = s.FirstName ?? string.Empty,

--- a/LMS.Services/StudentService.cs
+++ b/LMS.Services/StudentService.cs
@@ -106,5 +106,30 @@ namespace LMS.Services
                 Modules = modules
             };
         }
+
+        public async Task<IEnumerable<StudentDto>> GetCoursematesAsync(Guid studentId)
+        {
+            // Get student
+            var student = await unitOfWork.Students.GetStudentByIdAsync(studentId);
+
+            if (student == null || student.CourseId == null)
+            {
+                return null;
+            }
+
+            var course = await unitOfWork.Courses.GetCourseWithTeachersAsync(student.CourseId.Value);     //get course student is enrolled in
+
+            if (course == null)
+                return null;
+
+            IEnumerable<StudentDto> studentDto = course.Students.Select(s => new StudentDto //get all students in that course
+            {
+                Id = s.Id,
+                FirstName = s.FirstName ?? string.Empty,
+                LastName = s.LastName ?? string.Empty,
+                Email = s.Email ?? string.Empty,
+            }).ToList();
+            return studentDto;
+        }
     }
 }

--- a/Service.Contracts/IStudentService.cs
+++ b/Service.Contracts/IStudentService.cs
@@ -1,4 +1,5 @@
 ﻿using LMS.Shared.DTOs.CourseDTOs;
+using LMS.Shared.DTOs.UserDTOs;
 using LMS.Shared.DTOs.ModuleDTOs;
 
 namespace Service.Contracts
@@ -8,5 +9,6 @@ namespace Service.Contracts
         Task<CourseWithTeachersDto?> GetCourseForStudentAsync(Guid studentId);
         Task<IEnumerable<ModuleDto>> GetModulesForStudentAsync(Guid studentId);
         Task<CourseWithModulesDto?> GetCourseWithModulesForStudentAsync(Guid studentId);
+        Task<IEnumerable<StudentDto>> GetCoursematesAsync(Guid studentId);
     }
 }


### PR DESCRIPTION
 This pull request introduces a new feature that allows retrieval of a student's coursemates, enhancing the ability to view all students enrolled in the same course. The changes span the domain contracts, service layer, repository implementation, and presentation controller to support this functionality.

### Feature: Retrieve Coursemates for a Student

**Service and API Layer:**
* Added a new endpoint `GetCoursemates` to `StudentController`, enabling clients to fetch all coursemates for a given student by their ID.
* Introduced the `GetCoursematesAsync` method to the `IStudentService` interface, exposing the new functionality at the service contract level.
* Implemented the `GetCoursematesAsync` method in `StudentService`, which fetches the student's course and returns a list of coursemates as `StudentDto` objects.

**Repository Layer:**
* Added `GetCourseWithStudentsAsync` to the `ICourseRepository` interface to support loading a course along with its enrolled students.
* Implemented the `GetCourseWithStudentsAsync` method in `CourseRepository`, using eager loading to include the `Students` collection.

**Other Minor Changes:**
* Cleaned up unused DTO imports in `StudentController.cs`.
* No structural changes to the `ApplicationUser` entity, just whitespace adjustment.