### PR TITLE
As a teacher I need to be able to create and edit modules for courses

### DIFF
--- a/LMS.Presentation/Controllers/StudentController.cs
+++ b/LMS.Presentation/Controllers/StudentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using LMS.Shared.DTOs.UserDTOs;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 

--- a/LMS.Presentation/Controllers/TeachersController.cs
+++ b/LMS.Presentation/Controllers/TeachersController.cs
@@ -37,4 +37,23 @@ public class TeachersController : ControllerBase
             return StatusCode(500, new { message = "An unexpected error happened, probably runtime related. Please check logs.", details = ex.Message });
         }
     }
+
+    // GET: api/teachers/courses/{courseId}/modules
+    [HttpGet("courses/{courseId}/modules")]
+    [Authorize(Roles = "Teacher")]
+    // Fetch all modules belonging to a specific course
+    public async Task<IActionResult> GetModulesForCourse(Guid courseId)
+    {
+        try
+        {
+            var modules = await _serviceManager.ModuleService.GetByCourseIdAsync(courseId);
+            if (modules == null || !modules.Any())
+                return Ok(new List<object>()); // Return empty list if no modules
+            return Ok(modules);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = "An unexpected error happened, probably runtime related. Please check logs.", details = ex.Message });
+        }
+    }
 }

--- a/LMS.Presentation/LMS.Presentation.csproj
+++ b/LMS.Presentation/LMS.Presentation.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Service.Contracts\Service.Contracts.csproj" />
+	<ProjectReference Include="..\LMS.Shared\LMS.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LMS.Services/StudentService.cs
+++ b/LMS.Services/StudentService.cs
@@ -133,7 +133,6 @@ namespace LMS.Services
             return activityDtos;
         }
 
-
         public async Task<IEnumerable<StudentDto>> GetCoursematesAsync(Guid studentId)
         {
             var student = await unitOfWork.Students.GetStudentByIdAsync(studentId);

--- a/Service.Contracts/IStudentService.cs
+++ b/Service.Contracts/IStudentService.cs
@@ -1,6 +1,7 @@
 ﻿using LMS.Shared.DTOs.ActivityDTOs;
 using LMS.Shared.DTOs.CourseDTOs;
 using LMS.Shared.DTOs.ModuleDTOs;
+using LMS.Shared.DTOs.UserDTOs;
 using System.Reflection;
 
 namespace Service.Contracts


### PR DESCRIPTION
This pull request adds a new endpoint to the `TeachersController` to allow teachers to fetch all modules for a specific course. This improves the API's functionality for teachers by enabling them to view the modules associated with any course they teach.

New API functionality:

* Added `GetModulesForCourse` endpoint to `TeachersController`, allowing teachers to retrieve all modules for a given course via `GET /api/teachers/courses/{courseId}/modules`.

WORK IN PROGRESS......