### PR TITLE
removed username from coursemates view and export

### DIFF
--- a/LMS.Services/StudentService.cs
+++ b/LMS.Services/StudentService.cs
@@ -149,7 +149,6 @@ namespace LMS.Services
             var coursemates = course.Students
                 .Select(s => new CoursemateDto
                 {
-                    UserName = s.UserName ?? string.Empty,
                     FirstName = s.FirstName ?? string.Empty,
                     LastName = s.LastName ?? string.Empty,
                     Email = s.Email ?? string.Empty,

--- a/LMS.Shared/DTOs/UserDTOs/CoursemateDto.cs
+++ b/LMS.Shared/DTOs/UserDTOs/CoursemateDto.cs
@@ -8,7 +8,6 @@ namespace LMS.Shared.DTOs.UserDTOs;
 
 public class CoursemateDto
 {
-    public string UserName { get; set; } = null!;
     public string FirstName { get; set; } = null!;
     public string LastName { get; set; } = null!;
     public string Email { get; set; } = null!;


### PR DESCRIPTION
Minor changes, removed the transfer of username in regards to the coursemates view (student viewing students from the same course), now only firstname, lastname and email is transferred. 