### PR TITLE
add pagination / filtering for courses

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Domain.Models.Entities;
+using LMS.Shared.Parameters;
 
 namespace Domain.Contracts.Repositories
 {
@@ -13,5 +11,6 @@ namespace Domain.Contracts.Repositories
         Task<Course?> GetCourseWithTeachersAsync(Guid courseId);
         Task<Course?> GetCourseByIdAsync(Guid id, bool trackChanges = false);
         Task<IEnumerable<Course>> GetActiveCoursesExtendedAsync(bool trackChanges = false);
+        Task<PagedList<Course>> GetAllPagedAsync(CourseParameters parameters, bool trackChanges = false);
     }
 }

--- a/LMS.Infractructure/LMS.Infractructure.csproj
+++ b/LMS.Infractructure/LMS.Infractructure.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/LMS.Infractructure/LMS.Infractructure.csproj
+++ b/LMS.Infractructure/LMS.Infractructure.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/LMS.Infractructure/Repositories/RepositoryBase.cs
+++ b/LMS.Infractructure/Repositories/RepositoryBase.cs
@@ -1,7 +1,7 @@
 ﻿using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
-using Microsoft.AspNetCore.Identity;
+using LMS.Shared.Parameters;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -32,4 +32,7 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T>, IInternalRepositor
     public async Task<bool> EntityExistsAsync(Guid id) => await DbSet.AnyAsync(m => m.Id == id);
     public async Task<T?> GetEntityByIdAsync(Guid id, bool trackChanges = false)
             => await FindByCondition(e => e.Id == id, trackChanges).FirstOrDefaultAsync();
+
+    public async Task<PagedList<T>> GetPagedAsync(EntityParameters parameters, bool trackChanges = false)
+           => await PagedList<T>.PageAsync(FindAll(trackChanges), parameters.PageNumber, parameters.PageSize);
 }

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -77,6 +77,8 @@ public class CoursesController(IServiceManager serviceManager) : ControllerBase
             var paginationMetadata = new { courses.TotalCount, courses.CurrentPage, courses.PageSize, courses.TotalPages, courses.HasNext, courses.HasPrevious };
 
             Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(paginationMetadata));
+            Response.Headers.Add("Access-Control-Expose-Headers", "X-Pagination");
+
 
             return Ok(courses);
         }

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -1,10 +1,11 @@
 ﻿using LMS.Shared.DTOs.CourseDTOs;
-using LMS.Shared.DTOs.UserDTOs;
+using LMS.Shared.Parameters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 using Swashbuckle.AspNetCore.Annotations;
+using System.Text.Json;
 
 namespace LMS.Presentation.Controllers;
 
@@ -52,4 +53,41 @@ public class CoursesController(IServiceManager serviceManager) : ControllerBase
         var courses = await serviceManager.CourseService.GetActiveCoursesExtendedAsync();
         return Ok(courses);
     }
+
+    [HttpGet("archive")]
+    [Authorize(Roles = "Teacher")]
+    [SwaggerOperation(
+    Summary = "Retrieve paged list of courses",
+    Description = @"Returns all courses with optional pagination and filtering.
+        Supports:
+        - Exact match filtering by `Name`
+        - Partial search via `SearchQuery`
+        - Filtering by `StartDate` and `EndDate`
+        - Pagination metadata in the `X-Pagination` response header (TotalCount, CurrentPage, PageSize, TotalPages, HasNext, HasPrevious)")]
+
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CourseDto>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+
+    public async Task<ActionResult<IEnumerable<CourseDto>>> GetCoursesPagedAsync([FromQuery] CourseParameters parameters)
+    {
+        try
+        {
+            var courses = await serviceManager.CourseService.GetCoursesPagedAsync(parameters);
+            var paginationMetadata = new { courses.TotalCount, courses.CurrentPage, courses.PageSize, courses.TotalPages, courses.HasNext, courses.HasPrevious };
+
+            Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(paginationMetadata));
+
+            return Ok(courses);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = "An unexpected error occurred.", detail = ex.Message });
+        }
+    }
 }
+

--- a/LMS.Shared/LMS.Shared.csproj
+++ b/LMS.Shared/LMS.Shared.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+  </ItemGroup>
+
 </Project>

--- a/LMS.Shared/LMS.Shared.csproj
+++ b/LMS.Shared/LMS.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
   </ItemGroup>
 
 </Project>

--- a/LMS.Shared/Parameters/EntityParameters.cs
+++ b/LMS.Shared/Parameters/EntityParameters.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LMS.Shared.Parameters;
+public class EntityParameters
+{
+    const int maxPageSize = 10;
+    public int PageNumber { get; set; } = 1;
+    private int _pageSize { get; set; } = 5;
+    public string? SearchQuery { get; set; }
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = value > maxPageSize ? maxPageSize : value;
+    }
+}
+
+public class CourseParameters : EntityParameters
+{
+    public string? Name { get; set; }
+    public DateOnly? StartDate { get; set; }
+    public DateOnly? EndDate { get; set; }
+    public CourseParameters()
+    {
+        PageSize = 3;
+    }
+}

--- a/LMS.Shared/Parameters/PagedList.cs
+++ b/LMS.Shared/Parameters/PagedList.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace LMS.Shared.Parameters;
+public class PagedList<T> : List<T>
+{
+    public int CurrentPage { get; private set; }
+    public int TotalPages { get; private set; }
+    public int PageSize { get; private set; }
+    public int TotalCount { get; private set; }
+    public bool HasPrevious => CurrentPage > 1;
+    public bool HasNext => CurrentPage < TotalPages;
+
+    public PagedList(List<T> items, int count, int pageNumber, int pageSize)
+    {
+        TotalCount = count;
+        PageSize = pageSize;
+        CurrentPage = pageNumber;
+        TotalPages = (int)Math.Ceiling(count / (double)pageSize);
+        AddRange(items);
+    }
+
+    public static async Task<PagedList<T>> PageAsync(IQueryable<T> source, int pageNumber, int pageSize)
+    {
+        var count = source.Count();
+        var items = await source.Skip(pageSize * (pageNumber - 1)).Take(pageSize).ToListAsync();
+        return new PagedList<T>(items, count, pageNumber, pageSize);
+    }
+}

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -1,4 +1,5 @@
 using LMS.Shared.DTOs.CourseDTOs;
+using LMS.Shared.Parameters;
 
 namespace Service.Contracts;
 // Service contract for course-related operations
@@ -10,4 +11,5 @@ public interface ICourseService
     Task<CourseDto> CreateCourseAsync(CreateCourseDto createCourseDto);
     Task UpdateCourseAsync(Guid id, UpdateCourseDto updateCourseDto);
     Task<IEnumerable<CourseIdNameDto>> GetActiveCoursesExtendedAsync();
+    Task<PagedList<CourseDto>> GetCoursesPagedAsync(CourseParameters parameters, bool trackChanges = false);
 }


### PR DESCRIPTION
Added feature for Retrieving paged list of courses with optional filtering.
     Supports:
     - Exact match filtering by `Name`
     - Partial search via `SearchQuery`
     - Filtering by `StartDate` and `EndDate`
     - Pagination metadata in the `X-Pagination` response header  with (TotalCount, CurrentPage, PageSize, TotalPages, HasNext, HasPrevious)"